### PR TITLE
Potential fix for code scanning alert no. 4: Useless regular-expression character escape

### DIFF
--- a/js/extensions/bindings/numericExtender.js
+++ b/js/extensions/bindings/numericExtender.js
@@ -7,7 +7,7 @@ define(['knockout'], function (ko) {
                 const isNumeric = RegExp('^-?[0-9]*(?:\.[0-9]+)?$');
                 const isFloat = RegExp('^-?[0-9]*?\.[0-9]*$');
                 const isFloatWithNoMantissa = RegExp('^-?[0-9]\\.$');
-                const isFloatWithNoLeadingDigits = RegExp('^-?\.[0-9]*?$');
+                const isFloatWithNoLeadingDigits = RegExp('^-?\\.[0-9]*?$');
                 const hasCharacters = RegExp('.*[a-zA-Z]+.*');
                 if (newValue === null || newValue === "") {
                     target(null);


### PR DESCRIPTION
Potential fix for [https://github.com/NCI-C4CP/Atlas/security/code-scanning/4](https://github.com/NCI-C4CP/Atlas/security/code-scanning/4)

To fix the issue, we need to ensure that the backslash in the string literal is properly escaped. This involves replacing `\.` with `\\.` in the regular expression string. This change ensures that the `.` is interpreted as a literal period and not as a meta-character. The fix should be applied to line 10 of the file `js/extensions/bindings/numericExtender.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
