### PR TITLE
Potential fix for code scanning alert no. 2: Useless regular-expression character escape

### DIFF
--- a/js/extensions/bindings/numericExtender.js
+++ b/js/extensions/bindings/numericExtender.js
@@ -4,10 +4,10 @@ define(['knockout'], function (ko) {
         var result = ko.pureComputed({
             read: target,  //always return the original observables value
             write: function(newValue) {
-                const isNumeric = RegExp('^-?[0-9]*(?:\.[0-9]+)?$');
-                const isFloat = RegExp('^-?[0-9]*?\.[0-9]*$');
+                const isNumeric = RegExp('^-?[0-9]*(?:\\.[0-9]+)?$');
+                const isFloat = RegExp('^-?[0-9]*?\\.[0-9]*$');
                 const isFloatWithNoMantissa = RegExp('^-?[0-9]\\.$');
-                const isFloatWithNoLeadingDigits = RegExp('^-?\.[0-9]*?$');
+                const isFloatWithNoLeadingDigits = RegExp('^-?\\.[0-9]*?$');
                 const hasCharacters = RegExp('.*[a-zA-Z]+.*');
                 if (newValue === null || newValue === "") {
                     target(null);


### PR DESCRIPTION
Potential fix for [https://github.com/NCI-C4CP/Atlas/security/code-scanning/2](https://github.com/NCI-C4CP/Atlas/security/code-scanning/2)

To fix the issue, the escape sequence `\.` in the string literal should be corrected to `\\.`. This ensures that the backslash is properly escaped in the string literal, resulting in a regular expression that matches a literal period (`.`). The same correction should be applied to all similar occurrences in the file to ensure consistency and correctness.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
