### PR TITLE
Potential fix for code scanning alert no. 3: Useless regular-expression character escape

### DIFF
--- a/js/extensions/bindings/numericExtender.js
+++ b/js/extensions/bindings/numericExtender.js
@@ -5,7 +5,7 @@ define(['knockout'], function (ko) {
             read: target,  //always return the original observables value
             write: function(newValue) {
                 const isNumeric = RegExp('^-?[0-9]*(?:\.[0-9]+)?$');
-                const isFloat = RegExp('^-?[0-9]*?\.[0-9]*$');
+                const isFloat = RegExp('^-?[0-9]*?\\.[0-9]*$');
                 const isFloatWithNoMantissa = RegExp('^-?[0-9]\\.$');
                 const isFloatWithNoLeadingDigits = RegExp('^-?\.[0-9]*?$');
                 const hasCharacters = RegExp('.*[a-zA-Z]+.*');


### PR DESCRIPTION
Potential fix for [https://github.com/NCI-C4CP/Atlas/security/code-scanning/3](https://github.com/NCI-C4CP/Atlas/security/code-scanning/3)

To fix the issue, the backslash in the string literal must be doubled (`\\.`) to ensure that it is correctly interpreted as a literal backslash in the resulting regular expression. This will make the period (`.`) in the regular expression match a literal period instead of acting as a meta-character. The fix involves updating the regular expression on line 8 to use `'\\.'` instead of `'\.'`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
