### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/js/utils/CommonUtils.js
+++ b/js/utils/CommonUtils.js
@@ -190,7 +190,10 @@ define([
 		});
 	}
 	const escapeTooltip = function(tooltipText) {
-		return tooltipText.replace(/'/g, "\\'").replace(/"/g, '&quot;');
+		return tooltipText
+			.replace(/\\/g, '\\\\') // Escape backslashes
+			.replace(/'/g, "\\'")  // Escape single quotes
+			.replace(/"/g, '&quot;'); // Escape double quotes
 	}
 
 	const getSelectedConcepts = (conceptList) => {


### PR DESCRIPTION
Potential fix for [https://github.com/NCI-C4CP/Atlas/security/code-scanning/5](https://github.com/NCI-C4CP/Atlas/security/code-scanning/5)

To fix the issue, the `escapeTooltip` function should be updated to include escaping for backslashes (`\`). This can be achieved by adding a `.replace(/\\/g, '\\\\')` step before escaping single and double quotes. The order of replacements is important: backslashes should be escaped first to avoid interfering with subsequent replacements.

The updated function will:
1. Escape all backslashes by replacing each `\` with `\\`.
2. Escape all single quotes by replacing each `'` with `\'`.
3. Escape all double quotes by replacing each `"` with `&quot;`.

This ensures that all relevant meta-characters are properly escaped.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
